### PR TITLE
[App] call code generating Python bindings for STs

### DIFF
--- a/Applications/CLI/ogs_embedded_python.cpp
+++ b/Applications/CLI/ogs_embedded_python.cpp
@@ -13,12 +13,14 @@
 #include "ogs_embedded_python.h"
 
 #include "ProcessLib/BoundaryCondition/Python/PythonBoundaryConditionModule.h"
+#include "ProcessLib/SourceTerms/Python/PythonSourceTermModule.h"
 
 PYBIND11_EMBEDDED_MODULE(OpenGeoSys, m)
 {
     DBUG("Binding Python module OpenGeoSys.");
 
     ProcessLib::pythonBindBoundaryCondition(m);
+    ProcessLib::pythonBindSourceTerm(m);
 }
 
 #ifndef OGS_BUILD_SHARED_LIBS


### PR DESCRIPTION
Hallo Tom, hab dann zwischenzeitlich doch erst noch was anderes gemacht. Du hast einfach nur vergessen, die Python Bindings so zu registrieren, dass sie beim Programmstart eingerichtet werden. Mit folgendem Code sollten die STs gefunden werden.